### PR TITLE
Favorite Foods page with unit test completed

### DIFF
--- a/src/components/pages/FavoriteFoods.test.tsx
+++ b/src/components/pages/FavoriteFoods.test.tsx
@@ -105,18 +105,17 @@ describe('FavoriteFoods', () => {
       </TestProvider>,
     )
 
-    const sushi = screen.getByTestId('item0')
+    const first = screen.getByTestId('item0')
     const pizza = screen.getByTestId('item1')
 
     const SPACE = { key: ' ', code: 'Space', charCode: 32 }
     const ARROW_DOWN = { key: 'ArrowDown', code: 'ArrowDown', charCode: 40 }
 
-    sushi.focus()
-    expect(sushi).toHaveFocus()
-    await fireEvent.keyDown(sushi, SPACE)
-    await fireEvent.keyDown(sushi, ARROW_DOWN)
-    await fireEvent.keyDown(sushi, ARROW_DOWN)
-    await fireEvent.keyDown(sushi, SPACE)
+    first.focus()
+    expect(first).toHaveFocus()
+    await fireEvent.keyDown(first, SPACE)
+    await fireEvent.keyDown(first, ARROW_DOWN)
+    await fireEvent.keyDown(first, SPACE)
     // verticalDrag(sushi).inFrontOf(taco)
     // screen.debug()
 

--- a/src/components/pages/FavoriteFoods.test.tsx
+++ b/src/components/pages/FavoriteFoods.test.tsx
@@ -14,6 +14,7 @@ jest.mock('../../hooks/useFavorites', () => {
       favorites: [
         { id: 1, name: 'sushi' },
         { id: 2, name: 'pizza' },
+        { id: 3, name: 'taco' },
       ],
     }
   }
@@ -26,6 +27,11 @@ jest.mock('../../hooks/useUpdateFavorites', () => {
       loading: false,
       error: 'there is an error in updating favorite foods',
       success: true,
+      favorites: [
+        { id: 1, name: 'sushi' },
+        { id: 2, name: 'pizza' },
+        { id: 3, name: 'taco' },
+      ],
     }
   }
 })
@@ -35,7 +41,36 @@ jest.mock('react-router-dom', () => ({
   useParams: () => ({
     username: 'kitty',
   }),
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({
+    username: 'kitty',
+  }),
 }))
+
+// jest.mock('@hello-pangea/dnd', () => ({
+//   Droppable: ({ children }: any) =>
+//     children(
+//       {
+//         draggableProps: {
+//           style: {},
+//         },
+//         innerRef: jest.fn(),
+//       },
+//       {},
+//     ),
+//   Draggable: ({ children }: any) =>
+//     children(
+//       {
+//         draggableProps: {
+//           style: {},
+//         },
+//         innerRef: jest.fn(),
+//       },
+//       {},
+//     ),
+//   DragDropContext: ({ children }: any) => children,
+// }))
 
 describe('FavoriteFoods', () => {
   test('if currentUser matches profileUser, should display addFavorite component and draggable list of favoriteFoods. On mouse hover on list item, should show View Review button and Delete button', async () => {

--- a/src/components/pages/FavoriteFoods.test.tsx
+++ b/src/components/pages/FavoriteFoods.test.tsx
@@ -38,7 +38,7 @@ jest.mock('react-router-dom', () => ({
 }))
 
 describe('FavoriteFoods', () => {
-  test('if currentUser matches profileUser, should display addFavorite component draggable list of favoriteFoods', async () => {
+  test('if currentUser matches profileUser, should display addFavorite component and draggable list of favoriteFoods. On mouse hover on list item, should show View Review button and Delete button', async () => {
     render(
       <TestProvider>
         <UserContext.Provider
@@ -53,14 +53,24 @@ describe('FavoriteFoods', () => {
       </TestProvider>,
     )
 
-    expect(await screen.findByLabelText(/favorites-list-draggable/i)).toBeInTheDocument()
     const addFavoriteField = screen.getByRole('textbox', { name: /Add a new Favorite Dish/i })
     const addFavoriteBtn = screen.getByRole('button', { name: /add/i })
+    const draggableList = screen.findByLabelText(/favorites-list-draggable/i)
+    const firstListItem = screen.findByLabelText('item0')
+
     expect(addFavoriteField).toBeInTheDocument()
     expect(addFavoriteBtn).toBeInTheDocument()
+    expect(await draggableList).toBeInTheDocument()
+    expect(screen.queryByLabelText('viewReview-0')).not.toBeVisible()
+    expect(screen.queryByLabelText('delete-0')).not.toBeVisible()
+
+    await fireEvent.mouseEnter(await firstListItem)
+
+    expect(await screen.findByLabelText('viewReview-0')).toBeVisible()
+    expect(await screen.findByLabelText('delete-0')).toBeVisible()
   })
 
-  test('if currentUser matches profileUser, user should be able to drag and drop favorites to change order', async () => {
+  test('if currentUser matches profileUser, user should be able to drag and drop favorites to update favorites list to new order', async () => {
     render(
       <TestProvider>
         <UserContext.Provider
@@ -75,6 +85,7 @@ describe('FavoriteFoods', () => {
       </TestProvider>,
     )
 
+    // Library preset label for draggable list item
     const first = screen.getByLabelText('0')
 
     first.focus()
@@ -97,7 +108,7 @@ describe('FavoriteFoods', () => {
     })
   })
 
-  test('if currentUser does not match profileUser, should only display non-draggable list of favoritefoods', async () => {
+  test('if currentUser does not match profileUser, should only display non-draggable list of favoritefoods. On mouseHover on list item, should display View Reviews button', async () => {
     render(
       <TestProvider>
         <UserContext.Provider
@@ -118,31 +129,13 @@ describe('FavoriteFoods', () => {
     expect(screen.queryByLabelText(/favorites-list-draggable/i)).not.toBeInTheDocument()
 
     expect(await screen.findByLabelText(/favorites-otheruser/i)).toBeInTheDocument()
-  })
 
-  test('if food item has mouseHover, should show link button to View Reviews (otherwise button is hidden), and onClick View Reviews, should reroute to reviews page', () => {
-    render(
-      <TestProvider>
-        <UserContext.Provider
-          value={{
-            currentUser: { username: 'kitty', token: 'tokenString' },
-            setUser: jest.fn(),
-            clearUser: jest.fn(),
-          }}
-        >
-          <FavoriteFoods />
-        </UserContext.Provider>
-      </TestProvider>,
-    )
+    expect(screen.queryByLabelText('viewReview-0')).not.toBeVisible()
 
-    // expect(screen.findByLabelText('view-reviews'))
-    // const viewReviewsBtns
-    // const firstItem = screen.getByLabelText('item0')
+    const firstListItem = screen.findByLabelText('item0')
+    await fireEvent.mouseEnter(await firstListItem)
 
-    // expect(errorMsgUserFavs).toHaveTextContent('there is an error in fetching favorites')
-
-    const errorMsgUpdateFavs = screen.getByRole('error-message-updateFavs')
-    expect(errorMsgUpdateFavs).toHaveTextContent('there is an error in updating favorite foods')
+    expect(await screen.findByLabelText('viewReview-0')).toBeVisible()
   })
 
   test('if error in fetching favorites or updating favoriteFoods, should display error message', () => {

--- a/src/components/pages/FavoriteFoods.test.tsx
+++ b/src/components/pages/FavoriteFoods.test.tsx
@@ -14,7 +14,6 @@ jest.mock('../../hooks/useFavorites', () => {
       favorites: [
         { id: 1, name: 'sushi' },
         { id: 2, name: 'pizza' },
-        { id: 3, name: 'taco' },
       ],
     }
   }
@@ -27,11 +26,6 @@ jest.mock('../../hooks/useUpdateFavorites', () => {
       loading: false,
       error: 'there is an error in updating favorite foods',
       success: true,
-      favorites: [
-        { id: 1, name: 'sushi' },
-        { id: 2, name: 'pizza' },
-        { id: 3, name: 'taco' },
-      ],
     }
   }
 })
@@ -41,36 +35,7 @@ jest.mock('react-router-dom', () => ({
   useParams: () => ({
     username: 'kitty',
   }),
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useParams: () => ({
-    username: 'kitty',
-  }),
 }))
-
-// jest.mock('@hello-pangea/dnd', () => ({
-//   Droppable: ({ children }: any) =>
-//     children(
-//       {
-//         draggableProps: {
-//           style: {},
-//         },
-//         innerRef: jest.fn(),
-//       },
-//       {},
-//     ),
-//   Draggable: ({ children }: any) =>
-//     children(
-//       {
-//         draggableProps: {
-//           style: {},
-//         },
-//         innerRef: jest.fn(),
-//       },
-//       {},
-//     ),
-//   DragDropContext: ({ children }: any) => children,
-// }))
 
 describe('FavoriteFoods', () => {
   test('if currentUser matches profileUser, should display addFavorite component and draggable list of favoriteFoods. On mouse hover on list item, should show View Review button and Delete button', async () => {

--- a/src/components/pages/FavoriteFoods.test.tsx
+++ b/src/components/pages/FavoriteFoods.test.tsx
@@ -76,7 +76,6 @@ describe('FavoriteFoods', () => {
     )
 
     const first = screen.getByLabelText('0')
-    const second = screen.getByLabelText('1')
 
     first.focus()
     expect(first).toHaveFocus()

--- a/src/components/pages/FavoriteFoods.test.tsx
+++ b/src/components/pages/FavoriteFoods.test.tsx
@@ -75,6 +75,7 @@ describe('FavoriteFoods', () => {
       </TestProvider>,
     )
 
+    // preset label for first draggable element from library
     const first = screen.getByLabelText('0')
 
     first.focus()

--- a/src/components/pages/FavoriteFoods.test.tsx
+++ b/src/components/pages/FavoriteFoods.test.tsx
@@ -75,14 +75,15 @@ describe('FavoriteFoods', () => {
       </TestProvider>,
     )
 
-    // preset label for first draggable element from library
     const first = screen.getByLabelText('0')
 
     first.focus()
     expect(first).toHaveFocus()
 
     await fireEvent.keyDown(first, { key: ' ', keyCode: 32 })
+
     await fireEvent.keyDown(first, { key: 'ArrowDown', keyCode: 40 })
+
     await fireEvent.keyDown(first, { key: ' ', keyCode: 32 })
 
     expect(mockUpdateFoods).toBeCalledWith({

--- a/src/components/pages/FavoriteFoods.test.tsx
+++ b/src/components/pages/FavoriteFoods.test.tsx
@@ -14,7 +14,6 @@ jest.mock('../../hooks/useFavorites', () => {
       favorites: [
         { id: 1, name: 'sushi' },
         { id: 2, name: 'pizza' },
-        { id: 3, name: 'taco' },
       ],
     }
   }
@@ -27,11 +26,6 @@ jest.mock('../../hooks/useUpdateFavorites', () => {
       loading: false,
       error: 'there is an error in updating favorite foods',
       success: true,
-      favorites: [
-        { id: 1, name: 'sushi' },
-        { id: 2, name: 'pizza' },
-        { id: 3, name: 'taco' },
-      ],
     }
   }
 })
@@ -42,30 +36,6 @@ jest.mock('react-router-dom', () => ({
     username: 'kitty',
   }),
 }))
-
-// jest.mock('@hello-pangea/dnd', () => ({
-//   Droppable: ({ children }: any) =>
-//     children(
-//       {
-//         draggableProps: {
-//           style: {},
-//         },
-//         innerRef: jest.fn(),
-//       },
-//       {},
-//     ),
-//   Draggable: ({ children }: any) =>
-//     children(
-//       {
-//         draggableProps: {
-//           style: {},
-//         },
-//         innerRef: jest.fn(),
-//       },
-//       {},
-//     ),
-//   DragDropContext: ({ children }: any) => children,
-// }))
 
 describe('FavoriteFoods', () => {
   test('if currentUser matches profileUser, should display addFavorite component draggable list of favoriteFoods', async () => {
@@ -105,21 +75,25 @@ describe('FavoriteFoods', () => {
       </TestProvider>,
     )
 
-    const first = screen.getByTestId('item0')
-    const pizza = screen.getByTestId('item1')
-
-    const SPACE = { key: ' ', code: 'Space', charCode: 32 }
-    const ARROW_DOWN = { key: 'ArrowDown', code: 'ArrowDown', charCode: 40 }
+    const first = screen.getByLabelText('0')
+    const second = screen.getByLabelText('1')
 
     first.focus()
     expect(first).toHaveFocus()
-    await fireEvent.keyDown(first, SPACE)
-    await fireEvent.keyDown(first, ARROW_DOWN)
-    await fireEvent.keyDown(first, SPACE)
-    // verticalDrag(sushi).inFrontOf(taco)
-    // screen.debug()
 
-    expect(mockUpdateFoods).toBeCalled()
+    await fireEvent.keyDown(first, { key: ' ', keyCode: 32 })
+    await fireEvent.keyDown(first, { key: 'ArrowDown', keyCode: 40 })
+    await fireEvent.keyDown(first, { key: ' ', keyCode: 32 })
+
+    expect(mockUpdateFoods).toBeCalledWith({
+      username: 'kitty',
+      listFavoriteFoods: {
+        favoriteFoods: [
+          { id: 1, name: 'pizza' },
+          { id: 2, name: 'sushi' },
+        ],
+      },
+    })
   })
 
   test('if currentUser does not match profileUser, should only display non-draggable list of favoritefoods', async () => {

--- a/src/components/pages/FavoriteFoods.test.tsx
+++ b/src/components/pages/FavoriteFoods.test.tsx
@@ -120,6 +120,31 @@ describe('FavoriteFoods', () => {
     expect(await screen.findByLabelText(/favorites-otheruser/i)).toBeInTheDocument()
   })
 
+  test('if food item has mouseHover, should show link button to View Reviews (otherwise button is hidden), and onClick View Reviews, should reroute to reviews page', () => {
+    render(
+      <TestProvider>
+        <UserContext.Provider
+          value={{
+            currentUser: { username: 'kitty', token: 'tokenString' },
+            setUser: jest.fn(),
+            clearUser: jest.fn(),
+          }}
+        >
+          <FavoriteFoods />
+        </UserContext.Provider>
+      </TestProvider>,
+    )
+
+    // expect(screen.findByLabelText('view-reviews'))
+    // const viewReviewsBtns
+    // const firstItem = screen.getByLabelText('item0')
+
+    // expect(errorMsgUserFavs).toHaveTextContent('there is an error in fetching favorites')
+
+    const errorMsgUpdateFavs = screen.getByRole('error-message-updateFavs')
+    expect(errorMsgUpdateFavs).toHaveTextContent('there is an error in updating favorite foods')
+  })
+
   test('if error in fetching favorites or updating favoriteFoods, should display error message', () => {
     render(
       <TestProvider>

--- a/src/components/pages/FavoriteFoods.tsx
+++ b/src/components/pages/FavoriteFoods.tsx
@@ -2,6 +2,9 @@ import { DragDropContext, Draggable, Droppable } from '@hello-pangea/dnd'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import Container from '@mui/material/Container'
+import Paper from '@mui/material/Paper'
+import Stack from '@mui/material/Stack'
+import { styled } from '@mui/material/styles'
 import Typography from '@mui/material/Typography'
 import { useContext, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
@@ -23,11 +26,18 @@ export default function FavoriteFoods() {
   } = useFavorites({ username: profileUsername })
   const { error: errorUpdateFavorites, mutate: updateFavorites } = useUpdateFavorites()
   const [favsList, setFavsList] = useState<FavoriteFood[]>(favorites)
+  const [mouse, setMouse] = useState({
+    isHovering: false,
+    id: '',
+  })
 
-  const handleSelection = () => {
-    // TODO styling view review button based on mouse hover or click
-    console.log('review pop up')
-  }
+  const Item = styled(Paper)(({ theme }) => ({
+    backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
+    ...theme.typography.body2,
+    padding: theme.spacing(3),
+    textAlign: 'center',
+    color: theme.palette.text.secondary,
+  }))
 
   const handleUpdateFavorites = async (result: any) => {
     const items = Array.from(favsList)
@@ -70,12 +80,35 @@ export default function FavoriteFoods() {
                       aria-label={`${idx}`}
                       draggable
                     >
-                      <Box>
-                        {idx + 1}.{foodName}{' '}
-                        <Link to={`/${username}/reviews`} state={{ foodName: foodName }}>
-                          <Button>View Reviews</Button>
-                        </Link>
-                      </Box>
+                      <Stack spacing={4}>
+                        <Item
+                          onMouseOver={(e) =>
+                            setMouse({
+                              isHovering: true,
+                              id: (e.target as Element).id,
+                            })
+                          }
+                          onMouseOut={() =>
+                            setMouse({
+                              isHovering: false,
+                              id: '',
+                            })
+                          }
+                          id={`${idx}`}
+                        >
+                          {idx + 1}.{foodName}{' '}
+                          <Button
+                            sx={{
+                              display:
+                                mouse.isHovering && mouse.id === `${idx}` ? 'inline-block' : 'none',
+                            }}
+                          >
+                            <Link to={`/${username}/reviews`} state={{ foodName: foodName }}>
+                              View Reviews
+                            </Link>
+                          </Button>
+                        </Item>
+                      </Stack>
                     </Box>
                   )}
                 </Draggable>

--- a/src/components/pages/FavoriteFoods.tsx
+++ b/src/components/pages/FavoriteFoods.tsx
@@ -118,10 +118,10 @@ export default function FavoriteFoods() {
   )
 
   const otherUserDisplay = (
-    <Box aria-label='favorites-otheruser'>
+    <Stack aria-label='favorites-otheruser'>
       {favsList.map(({ id, name: foodName }, idx) => {
         return (
-          <Typography
+          <Item
             key={id}
             aria-label={`item${idx}`}
             onMouseEnter={(e) => setMouseIdx((e.target as Element).id)}
@@ -140,10 +140,10 @@ export default function FavoriteFoods() {
                 View Reviews
               </Button>
             </Link>
-          </Typography>
+          </Item>
         )
       })}
-    </Box>
+    </Stack>
   )
 
   return (

--- a/src/components/pages/FavoriteFoods.tsx
+++ b/src/components/pages/FavoriteFoods.tsx
@@ -56,7 +56,12 @@ export default function FavoriteFoods() {
               aria-label='favorites-list-draggable'
             >
               {favsList.map(({ id, name: foodName }, idx) => (
-                <Draggable key={`${id}`} draggableId={`${id}`} index={idx}>
+                <Draggable
+                  key={`${id}`}
+                  draggableId={`${id}`}
+                  index={idx}
+                  aria-label={`item${idx}`}
+                >
                   {(provided) => (
                     <Box
                       ref={provided.innerRef}
@@ -65,7 +70,7 @@ export default function FavoriteFoods() {
                       aria-label={`${idx}`}
                       draggable
                     >
-                      <Box data-testid={`item${idx}`}>
+                      <Box>
                         {idx + 1}.{foodName}{' '}
                         <Link to={`/${username}/reviews`} state={{ foodName: foodName }}>
                           <Button>View Reviews</Button>

--- a/src/components/pages/FavoriteFoods.tsx
+++ b/src/components/pages/FavoriteFoods.tsx
@@ -1,4 +1,4 @@
-import { DragDropContext, Draggable, Droppable } from '@hello-pangea/dnd'
+import { DragDropContext, Draggable, Droppable, DropResult } from '@hello-pangea/dnd'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import Container from '@mui/material/Container'
@@ -37,10 +37,10 @@ export default function FavoriteFoods() {
     color: theme.palette.text.secondary,
   }))
 
-  const handleUpdateFavorites = async (result: any) => {
+  const handleUpdateFavorites = async (result: DropResult) => {
     const items = Array.from(favsList)
     const [reorderedItem] = items.splice(result.source.index, 1)
-    items.splice(result.destination.index, 0, reorderedItem)
+    items.splice(result.destination!.index, 0, reorderedItem)
     items.forEach((item, index) => {
       item.id = index + 1
     })

--- a/src/components/pages/FavoriteFoods.tsx
+++ b/src/components/pages/FavoriteFoods.tsx
@@ -63,15 +63,14 @@ export default function FavoriteFoods() {
                       {...provided.draggableProps}
                       {...provided.dragHandleProps}
                       aria-label={`${idx}`}
-                      data-testid={`item${idx}`}
                       draggable
                     >
-                      <Typography>
+                      <Box data-testid={`item${idx}`}>
                         {idx + 1}.{foodName}{' '}
                         <Link to={`/${username}/reviews`} state={{ foodName: foodName }}>
                           <Button>View Reviews</Button>
                         </Link>
-                      </Typography>
+                      </Box>
                     </Box>
                   )}
                 </Draggable>

--- a/src/components/pages/FavoriteFoods.tsx
+++ b/src/components/pages/FavoriteFoods.tsx
@@ -52,16 +52,10 @@ export default function FavoriteFoods() {
 
   const currentUserDisplay = (
     <>
-
       <AddFavorite username={profileUsername} favorites={favsList} />
       <DragDropContext onDragEnd={handleUpdateFavorites}>
         <Droppable droppableId='favorites'>
           {(provided) => (
-            <Box
-              {...provided.droppableProps}
-              ref={provided.innerRef}
-              aria-label='favorites-list-draggable'
-            >
             <Box
               {...provided.droppableProps}
               ref={provided.innerRef}
@@ -80,7 +74,6 @@ export default function FavoriteFoods() {
                       {...provided.draggableProps}
                       {...provided.dragHandleProps}
                       aria-label={`${idx}`}
-                      data-testid={`item${idx}`}
                       draggable
                     >
                       <FoodItem
@@ -155,10 +148,10 @@ export default function FavoriteFoods() {
     <Spinner loading={loadingFavorites}>
       <Container fixed>
         <Typography role='error-message-userFavs'>
-          {errorFavorites && `${errorFavorites}`}
+          {errorFavorites ? `${errorFavorites}` : ''}
         </Typography>
         <Typography role='error-message-updateFavs'>
-          {errorUpdateFavorites && `${errorUpdateFavorites}`}
+          {errorUpdateFavorites ? `${errorUpdateFavorites}` : ''}
         </Typography>
         {currentUser!.username === profileUsername ? currentUserDisplay : otherUserDisplay}
       </Container>

--- a/src/components/pages/FavoriteFoods.tsx
+++ b/src/components/pages/FavoriteFoods.tsx
@@ -38,12 +38,10 @@ export default function FavoriteFoods() {
   }))
 
   const handleUpdateFavorites = async (result: DropResult) => {
-    const items = Array.from(favsList)
+    let items = Array.from(favsList)
     const [reorderedItem] = items.splice(result.source.index, 1)
     items.splice(result.destination!.index, 0, reorderedItem)
-    items.forEach((item, index) => {
-      item.id = index + 1
-    })
+    items = items.map((item, idx) => ({ ...item, id: idx + 1 }))
     await updateFavorites({
       username: currentUser!.username,
       listFavoriteFoods: { favoriteFoods: items },

--- a/src/components/pages/FavoriteFoods.tsx
+++ b/src/components/pages/FavoriteFoods.tsx
@@ -12,6 +12,7 @@ import { FavoriteFood } from '../../client/flavorite'
 import useFavorites from '../../hooks/useFavorites'
 import useUpdateFavorites from '../../hooks/useUpdateFavorites'
 import AddFavorite from '../partials/AddFavorite'
+import DeleteFavorite from '../partials/DeleteFavorite'
 import Spinner from '../partials/Spinner'
 import { UserContext } from '../partials/UserContext'
 
@@ -40,8 +41,8 @@ export default function FavoriteFoods() {
     const items = Array.from(favsList)
     const [reorderedItem] = items.splice(result.source.index, 1)
     items.splice(result.destination.index, 0, reorderedItem)
-    items.forEach((item, idx) => {
-      item.id = idx + 1
+    items.forEach((item, index) => {
+      item.id = index + 1
     })
     await updateFavorites({
       username: currentUser!.username,
@@ -81,6 +82,7 @@ export default function FavoriteFoods() {
                         onMouseEnter={(e) => setMouseIdx((e.target as Element).id)}
                         onMouseLeave={() => setMouseIdx('none')}
                         id={`${idx}`}
+                        aria-label={`item${idx}`}
                       >
                         {idx + 1}.{foodName}{' '}
                         <Link to={`/${username}/reviews`} state={{ foodName: foodName }}>
@@ -89,10 +91,19 @@ export default function FavoriteFoods() {
                               display: mouseIdx === `${idx}` ? 'inline-block' : 'none',
                               pointerEvents: 'none',
                             }}
+                            aria-label='view-reviews'
                           >
                             View Reviews
                           </Button>
                         </Link>
+                        <DeleteFavorite
+                          foodName={foodName}
+                          mouseIdx={mouseIdx}
+                          idx={idx}
+                          favsList={favsList}
+                          setFavsList={setFavsList}
+                          username={currentUser!.username}
+                        />
                       </Item>
                     </Stack>
                   )}
@@ -110,10 +121,24 @@ export default function FavoriteFoods() {
     <Box aria-label='favorites-otheruser'>
       {favsList.map(({ id, name: foodName }, idx) => {
         return (
-          <Typography key={id}>
+          <Typography
+            key={id}
+            aria-label={`item${idx}`}
+            onMouseEnter={(e) => setMouseIdx((e.target as Element).id)}
+            onMouseLeave={() => setMouseIdx('none')}
+            id={`${idx}`}
+          >
             {idx + 1}.{foodName}{' '}
             <Link to={`/${profileUsername}/reviews`} state={{ foodName: foodName }}>
-              <Button>View Reviews</Button>
+              <Button
+                sx={{
+                  display: mouseIdx === `${idx}` ? 'inline-block' : 'none',
+                  pointerEvents: 'none',
+                }}
+                role='view-reviews'
+              >
+                View Reviews
+              </Button>
             </Link>
           </Typography>
         )

--- a/src/components/pages/FavoriteFoods.tsx
+++ b/src/components/pages/FavoriteFoods.tsx
@@ -62,6 +62,11 @@ export default function FavoriteFoods() {
               ref={provided.innerRef}
               aria-label='favorites-list-draggable'
             >
+            <Box
+              {...provided.droppableProps}
+              ref={provided.innerRef}
+              aria-label='favorites-list-draggable'
+            >
               {favsList.map(({ id, name: foodName }, idx) => (
                 <Draggable
                   key={`${id}`}
@@ -75,6 +80,7 @@ export default function FavoriteFoods() {
                       {...provided.draggableProps}
                       {...provided.dragHandleProps}
                       aria-label={`${idx}`}
+                      data-testid={`item${idx}`}
                       draggable
                     >
                       <FoodItem

--- a/src/components/pages/FavoriteFoods.tsx
+++ b/src/components/pages/FavoriteFoods.tsx
@@ -26,10 +26,7 @@ export default function FavoriteFoods() {
   } = useFavorites({ username: profileUsername })
   const { error: errorUpdateFavorites, mutate: updateFavorites } = useUpdateFavorites()
   const [favsList, setFavsList] = useState<FavoriteFood[]>(favorites)
-  const [mouse, setMouse] = useState({
-    isHovering: false,
-    id: '',
-  })
+  const [mouseIdx, setMouseIdx] = useState('none')
 
   const Item = styled(Paper)(({ theme }) => ({
     backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
@@ -73,43 +70,31 @@ export default function FavoriteFoods() {
                   aria-label={`item${idx}`}
                 >
                   {(provided) => (
-                    <Box
+                    <Stack
                       ref={provided.innerRef}
                       {...provided.draggableProps}
                       {...provided.dragHandleProps}
                       aria-label={`${idx}`}
                       draggable
                     >
-                      <Stack spacing={4}>
-                        <Item
-                          onMouseOver={(e) =>
-                            setMouse({
-                              isHovering: true,
-                              id: (e.target as Element).id,
-                            })
-                          }
-                          onMouseOut={() =>
-                            setMouse({
-                              isHovering: false,
-                              id: '',
-                            })
-                          }
-                          id={`${idx}`}
-                        >
-                          {idx + 1}.{foodName}{' '}
+                      <Item
+                        onMouseEnter={(e) => setMouseIdx((e.target as Element).id)}
+                        onMouseLeave={() => setMouseIdx('none')}
+                        id={`${idx}`}
+                      >
+                        {idx + 1}.{foodName}{' '}
+                        <Link to={`/${username}/reviews`} state={{ foodName: foodName }}>
                           <Button
                             sx={{
-                              display:
-                                mouse.isHovering && mouse.id === `${idx}` ? 'inline-block' : 'none',
+                              display: mouseIdx === `${idx}` ? 'inline-block' : 'none',
+                              pointerEvents: 'none',
                             }}
                           >
-                            <Link to={`/${username}/reviews`} state={{ foodName: foodName }}>
-                              View Reviews
-                            </Link>
+                            View Reviews
                           </Button>
-                        </Item>
-                      </Stack>
-                    </Box>
+                        </Link>
+                      </Item>
+                    </Stack>
                   )}
                 </Draggable>
               ))}

--- a/src/components/pages/FavoriteFoods.tsx
+++ b/src/components/pages/FavoriteFoods.tsx
@@ -91,7 +91,7 @@ export default function FavoriteFoods() {
                               display: mouseIdx === `${idx}` ? 'inline-block' : 'none',
                               pointerEvents: 'none',
                             }}
-                            aria-label='view-reviews'
+                            aria-label={`viewReview-${idx}`}
                           >
                             View Reviews
                           </Button>
@@ -135,7 +135,7 @@ export default function FavoriteFoods() {
                   display: mouseIdx === `${idx}` ? 'inline-block' : 'none',
                   pointerEvents: 'none',
                 }}
-                role='view-reviews'
+                aria-label={`viewReview-${idx}`}
               >
                 View Reviews
               </Button>

--- a/src/components/pages/FavoriteFoods.tsx
+++ b/src/components/pages/FavoriteFoods.tsx
@@ -46,15 +46,15 @@ export default function FavoriteFoods() {
 
   const currentUserDisplay = (
     <>
-      <AddFavorite username={currentUser!.username} favorites={favorites} />
-      <Typography role='error-message-userFavs'>{errorFavorites && `${errorFavorites}`}</Typography>
-      <Typography role='error-message-updateFavs'>
-        {errorUpdateFavorites && `${errorUpdateFavorites}`}
-      </Typography>
+      <AddFavorite username={profileUsername} favorites={favsList} />
       <DragDropContext onDragEnd={handleUpdateFavorites}>
         <Droppable droppableId='favorites'>
           {(provided) => (
-            <Box {...provided.droppableProps} ref={provided.innerRef} aria-label='favorites-list'>
+            <Box
+              {...provided.droppableProps}
+              ref={provided.innerRef}
+              aria-label='favorites-list-draggable'
+            >
               {favsList.map(({ id, name: foodName }, idx) => (
                 <Draggable key={`${id}`} draggableId={`${id}`} index={idx}>
                   {(provided) => (
@@ -63,8 +63,8 @@ export default function FavoriteFoods() {
                       {...provided.draggableProps}
                       {...provided.dragHandleProps}
                       aria-label={`${idx}`}
+                      data-testid={`item${idx}`}
                       draggable
-                      data-testid='item'
                     >
                       <Typography>
                         {idx + 1}.{foodName}{' '}
@@ -84,22 +84,30 @@ export default function FavoriteFoods() {
     </>
   )
 
-  const otherUserDisplay = favsList.map(({ id, name: foodName }, idx) => {
-    return (
-      <Box key={id} data-testid='favorites-other'>
-        <Typography>
-          {idx + 1}.{foodName}{' '}
-          <Link to={`/${profileUsername}/reviews`} state={{ foodName: foodName }}>
-            <Button>View Reviews</Button>
-          </Link>
-        </Typography>
-      </Box>
-    )
-  })
+  const otherUserDisplay = (
+    <Box aria-label='favorites-otheruser'>
+      {favsList.map(({ id, name: foodName }, idx) => {
+        return (
+          <Typography key={id}>
+            {idx + 1}.{foodName}{' '}
+            <Link to={`/${profileUsername}/reviews`} state={{ foodName: foodName }}>
+              <Button>View Reviews</Button>
+            </Link>
+          </Typography>
+        )
+      })}
+    </Box>
+  )
 
   return (
     <Spinner loading={loadingFavorites}>
       <Container fixed>
+        <Typography role='error-message-userFavs'>
+          {errorFavorites && `${errorFavorites}`}
+        </Typography>
+        <Typography role='error-message-updateFavs'>
+          {errorUpdateFavorites && `${errorUpdateFavorites}`}
+        </Typography>
         {currentUser!.username === profileUsername ? currentUserDisplay : otherUserDisplay}
       </Container>
     </Spinner>

--- a/src/components/pages/FavoriteFoods.tsx
+++ b/src/components/pages/FavoriteFoods.tsx
@@ -29,7 +29,7 @@ export default function FavoriteFoods() {
   const [favsList, setFavsList] = useState<FavoriteFood[]>(favorites)
   const [mouseIdx, setMouseIdx] = useState('none')
 
-  const Item = styled(Paper)(({ theme }) => ({
+  const FoodItem = styled(Paper)(({ theme }) => ({
     backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
     ...theme.typography.body2,
     padding: theme.spacing(3),
@@ -76,7 +76,7 @@ export default function FavoriteFoods() {
                       aria-label={`${idx}`}
                       draggable
                     >
-                      <Item
+                      <FoodItem
                         onMouseEnter={(e) => setMouseIdx((e.target as Element).id)}
                         onMouseLeave={() => setMouseIdx('none')}
                         id={`${idx}`}
@@ -102,7 +102,7 @@ export default function FavoriteFoods() {
                           setFavsList={setFavsList}
                           username={currentUser!.username}
                         />
-                      </Item>
+                      </FoodItem>
                     </Stack>
                   )}
                 </Draggable>
@@ -119,7 +119,7 @@ export default function FavoriteFoods() {
     <Stack aria-label='favorites-otheruser'>
       {favsList.map(({ id, name: foodName }, idx) => {
         return (
-          <Item
+          <FoodItem
             key={id}
             aria-label={`item${idx}`}
             onMouseEnter={(e) => setMouseIdx((e.target as Element).id)}
@@ -138,7 +138,7 @@ export default function FavoriteFoods() {
                 View Reviews
               </Button>
             </Link>
-          </Item>
+          </FoodItem>
         )
       })}
     </Stack>

--- a/src/components/pages/Friends.tsx
+++ b/src/components/pages/Friends.tsx
@@ -29,7 +29,7 @@ export default function Friends() {
     } else {
       setEnabled(false)
     }
-  }, [])
+  }, [friends])
 
   const friendsList = friends.map((friend, id) => {
     return (

--- a/src/components/pages/UserReviews.tsx
+++ b/src/components/pages/UserReviews.tsx
@@ -43,7 +43,7 @@ export default function FavoriteFood() {
           onInputChange={(event, newInputValue) => {
             setInputValue(newInputValue)
           }}
-          sx={{ width: 300 }}
+          sx={{ width: 300, marginTop: 5 }}
           renderInput={(params) => <TextField {...params} label='Favorite Dishes' />}
           aria-label='selectFavs'
         />

--- a/src/components/partials/AddFavorite.test.tsx
+++ b/src/components/partials/AddFavorite.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import AddFavorite from './AddFavorite'
 import TestProvider from './TestProvider'
@@ -53,7 +53,7 @@ describe('AddFavorite', () => {
     expect(addFavoriteField).toHaveValue('tacos')
   })
 
-  test('onSubmit, should post form data to update FavoriteFoods', async () => {
+  test('onSubmit, should post form data to update FavoriteFoods and clear textField', async () => {
     render(
       <TestProvider>
         <AddFavorite
@@ -68,7 +68,7 @@ describe('AddFavorite', () => {
     const addFavoriteField = screen.getByRole('textbox', {
       name: /Add a new Favorite Dish/i,
     }) as HTMLInputElement
-    fireEvent.change(addFavoriteField, { target: { value: 'tacos' } })
+    await userEvent.type(addFavoriteField, 'tacos')
 
     const addFavoriteBtn = screen.getByRole('button', { name: /add/i })
     await userEvent.click(addFavoriteBtn)
@@ -82,6 +82,10 @@ describe('AddFavorite', () => {
           { id: 3, name: 'tacos' },
         ],
       },
+    })
+
+    await waitFor(() => {
+      expect(addFavoriteField.value).toBe('')
     })
   })
 

--- a/src/components/partials/AddFavorite.tsx
+++ b/src/components/partials/AddFavorite.tsx
@@ -3,6 +3,7 @@ import Box from '@mui/material/Box'
 import Fab from '@mui/material/Fab'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
+import { useState } from 'react'
 import useUpdateFavorites from '../../hooks/useUpdateFavorites'
 import Spinner from './Spinner'
 
@@ -12,6 +13,7 @@ type favProps = {
 }
 
 export default function AddFavorite({ username, favorites }: favProps) {
+  const [inputValue, setInputValue] = useState<string>('')
   const {
     loading: loadingUpdateFavorites,
     error: errorUpdateFavorites,
@@ -20,14 +22,13 @@ export default function AddFavorite({ username, favorites }: favProps) {
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()
-    const inputForm = new FormData(event.currentTarget)
-    const input = inputForm.get('favorite') as string
     const newFavorites = favorites
-    newFavorites.push({ id: favorites.length + 1, name: input })
+    newFavorites.push({ id: favorites.length + 1, name: inputValue })
     await updateFavorites({
       username: username,
       listFavoriteFoods: { favoriteFoods: newFavorites },
     })
+    setInputValue('')
   }
   return (
     <Spinner loading={loadingUpdateFavorites}>
@@ -38,6 +39,8 @@ export default function AddFavorite({ username, favorites }: favProps) {
           label='Add a new Favorite Dish'
           name='favorite'
           variant='standard'
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
         />
         <Fab color='primary' aria-label='add' role='button' type='submit'>
           <AddIcon />

--- a/src/components/partials/DeleteFavorite.tsx
+++ b/src/components/partials/DeleteFavorite.tsx
@@ -79,8 +79,7 @@ export default function DeleteFavorite({
           <DialogTitle id='alert-dialog-title'>{'Are you sure?'}</DialogTitle>
           <DialogContent>
             <DialogContentText id='alert-dialog-description'>
-              This will also delete all reviews you have posted for {foodName}. <br></br>Please
-              click Delete if you want to proceed with deletion.
+              This may also delete reviews you have posted for {foodName}.
             </DialogContentText>
           </DialogContent>
           <DialogActions>

--- a/src/components/partials/DeleteFavorite.tsx
+++ b/src/components/partials/DeleteFavorite.tsx
@@ -62,7 +62,7 @@ export default function DeleteFavorite({
     <Spinner loading={loadingUpdateFavorites}>
       <Box>
         <IconButton
-          aria-label='delete'
+          aria-label={`delete-${idx}`}
           sx={{
             display: mouseIdx === `${idx}` ? 'inline-block' : 'none',
           }}

--- a/src/components/partials/DeleteFavorite.tsx
+++ b/src/components/partials/DeleteFavorite.tsx
@@ -1,0 +1,100 @@
+import DeleteIcon from '@mui/icons-material/Delete'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Dialog from '@mui/material/Dialog'
+import DialogActions from '@mui/material/DialogActions'
+import DialogContent from '@mui/material/DialogContent'
+import DialogContentText from '@mui/material/DialogContentText'
+import DialogTitle from '@mui/material/DialogTitle'
+import IconButton from '@mui/material/IconButton'
+import Typography from '@mui/material/Typography'
+import { useState } from 'react'
+import { FavoriteFood } from '../../client/flavorite'
+import useUpdateFavorites from '../../hooks/useUpdateFavorites'
+import Spinner from './Spinner'
+
+type deleteFavsProps = {
+  favsList: FavoriteFood[]
+  idx: number
+  mouseIdx: string
+  foodName: string
+  setFavsList: (list: FavoriteFood[]) => void
+  username: string
+}
+
+export default function DeleteFavorite({
+  idx,
+  mouseIdx,
+  foodName,
+  favsList,
+  setFavsList,
+  username,
+}: deleteFavsProps) {
+  const {
+    loading: loadingUpdateFavorites,
+    error: errorUpdateFavorites,
+    mutate: updateFavorites,
+  } = useUpdateFavorites()
+  const [open, setOpen] = useState(false)
+
+  const handleClickOpen = () => {
+    setOpen(true)
+  }
+
+  const handleClose = () => {
+    setOpen(false)
+  }
+
+  const handleDelete = async () => {
+    const newFavorites = favsList.filter((item, index) => index !== idx)
+    newFavorites.forEach((item, index) => {
+      item.id = index + 1
+    })
+    await updateFavorites({
+      username: username,
+      listFavoriteFoods: { favoriteFoods: newFavorites },
+    })
+    // TODO change this to either updatedFavs or getFavs when API is hooked
+    setFavsList(newFavorites)
+  }
+
+  return (
+    <Spinner loading={loadingUpdateFavorites}>
+      <Box>
+        <IconButton
+          aria-label='delete'
+          sx={{
+            display: mouseIdx === `${idx}` ? 'inline-block' : 'none',
+          }}
+          onClick={handleClickOpen}
+        >
+          <DeleteIcon />
+        </IconButton>
+        <Dialog
+          open={open}
+          onClose={handleClose}
+          aria-labelledby='alert-dialog-title'
+          aria-describedby='alert-dialog-description'
+        >
+          <DialogTitle id='alert-dialog-title'>{'Are you sure?'}</DialogTitle>
+          <DialogContent>
+            <DialogContentText id='alert-dialog-description'>
+              This will also delete all reviews you have posted for {foodName}. <br></br>Please
+              click Delete if you want to proceed with deletion.
+            </DialogContentText>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={handleDelete}>Delete</Button>
+            <Button onClick={handleClose} autoFocus>
+              Cancel
+            </Button>
+          </DialogActions>
+        </Dialog>
+        <Typography role='error-message'>
+          {/* TODO Style Typography */}
+          {errorUpdateFavorites && `${errorUpdateFavorites}`}
+        </Typography>
+      </Box>
+    </Spinner>
+  )
+}

--- a/src/components/partials/UserReviewsByFood.tsx
+++ b/src/components/partials/UserReviewsByFood.tsx
@@ -25,7 +25,7 @@ export default function UserReviews({ inputValue, profileUsername }: reviewProps
   const [reviewsToDisplay, setReviewsToDisplay] = useState<ListReviews['reviews']>(reviews)
 
   useEffect(() => {
-    if (inputValue !== 'All') {
+    if (inputValue !== 'All' && inputValue !== '') {
       const filteredReviews = reviews.filter((review) => {
         return review.favoriteFood === inputValue
       })


### PR DESCRIPTION
To Review on this PR:
- FavoriteFoods / Test : ended up testing drag/drop with Keyboard activities as the library supports full keyboard access. 
- Small change made on AddFavorite to clear the textfield after submission

In progress (next PR):
- DeleteFavorites : created partial for FavoriteFoods, will submit new PR with Test


View when mouse not hovering:
<img width="1438" alt="Not hover" src="https://user-images.githubusercontent.com/110070272/209904138-81596b15-9098-4e33-9968-8ac8141eccda.png">

Current User view when mouse is hovering:
<img width="1346" alt="currentUser- hover" src="https://user-images.githubusercontent.com/110070272/209904153-6ad636e7-9503-4313-b69a-3cf383a29d83.png">

OtherUser page view when mouse is hovering:
<img width="1386" alt="otherUser-hover" src="https://user-images.githubusercontent.com/110070272/209904167-db8d8a1b-c23c-45bf-a9e4-5e13e1d71a00.png">

